### PR TITLE
kick lots of LuaUtils usage

### DIFF
--- a/match2/commons/brkts_wiki_specific_base.lua
+++ b/match2/commons/brkts_wiki_specific_base.lua
@@ -74,13 +74,13 @@ Called from MatchGroup/Display
 -- @returns module
 ]]
 WikiSpecificBase.getMatchGroupModule = function(matchGroupType)
-	local LuaUtils = require('Module:LuaUtils')
+	local Lua = require('Module:Lua')
 	local DevFlags = require('Module:DevFlags')
 	if matchGroupType == 'matchlist' then
-		return DevFlags.matchGroupDev and LuaUtils.lua.requireIfExists('Module:MatchGroup/Display/Matchlist/dev')
+		return DevFlags.matchGroupDev and Lua.requireIfExists('Module:MatchGroup/Display/Matchlist/dev')
 			or require('Module:MatchGroup/Display/Matchlist')
 	else -- matchGroupType == 'bracket'
-		return DevFlags.matchGroupDev and LuaUtils.lua.requireIfExists('Module:MatchGroup/Display/Bracket/dev')
+		return DevFlags.matchGroupDev and Lua.requireIfExists('Module:MatchGroup/Display/Bracket/dev')
 			or require('Module:MatchGroup/Display/Bracket')
 	end
 end

--- a/match2/commons/match.lua
+++ b/match2/commons/match.lua
@@ -2,11 +2,13 @@ local p = {}
 
 local getArgs = require("Module:Arguments").getArgs
 local json = require("Module:Json")
-local utils = require("Module:LuaUtils")
+local Logic = require("Module:Logic")
+local Lua = require("Module:Lua")
+local Table = require("Module:Table")
 local args
 
-local legacy = utils.lua.moduleExists("Module:Match/Legacy") and require("Module:Match/Legacy") or nil
-local config = utils.lua.moduleExists("Module:Match/Config") and require("Module:Match/Config") or {}
+local legacy = Lua.moduleExists("Module:Match/Legacy") and require("Module:Match/Legacy") or nil
+local config = Lua.moduleExists("Module:Match/Config") and require("Module:Match/Config") or {}
 
 local MAX_NUM_MAPS = config.MAX_NUM_MAPS or 20
 
@@ -19,7 +21,7 @@ function p.toEncodedJson(frame)
   	-- handle tbd and literals for opponents
   	for opponentIndex = 1, args["1"] or 2 do
 		opponent = args["opponent" .. opponentIndex]
-		if utils.misc.isEmpty(opponent) then
+		if Logic.isEmpty(opponent) then
 	  		args["opponent" .. opponentIndex] = { ["type"] = "literal", template = "tbd", name = args["opponent" .. opponentIndex .. "literal"] }
 	  	end
 	end
@@ -94,7 +96,7 @@ function p.templateFromMatchID(frame)
 end
 
 function storeLegacy(parameters, rawOpponents, rawGames)
-	local rawMatch = utils.table.shallowCopy(parameters)
+	local rawMatch = Table.deepCopy(parameters)
 	rawMatch.match2opponents = rawOpponents
 	rawMatch.match2games = rawGames
 	legacy.storeMatch(rawMatch)
@@ -136,7 +138,7 @@ function storeOpponents(args, staticid, opponentPlayers)
 	  	end
 	
 		-- get nested players if exist
-		if not utils.misc.isEmpty(opponent.match2players) then
+		if not Logic.isEmpty(opponent.match2players) then
 			local players = opponent.match2players or {}
 			if type(players) == "string" then
 				players = json.parse(players)
@@ -203,12 +205,12 @@ function buildParameters(args)
 		winner = args["winner"],
 		walkover = args["walkover"],
 		resulttype = args["resulttype"],
-		finished = utils.misc.readBool(args["finished"]) and 1 or 0,
+		finished = Logic.readBool(args["finished"]) and 1 or 0,
 		mode = args["mode"],
 		type = args["type"],
 		game = args["game"],
 		date = args["date"],
-		dateexact = utils.misc.readBool(args["dateexact"]) and 1 or 0,
+		dateexact = Logic.readBool(args["dateexact"]) and 1 or 0,
 		stream = args["stream"],
 		bestof = args["bestof"],
 		links = args["links"],

--- a/match2/commons/match_group_base.lua
+++ b/match2/commons/match_group_base.lua
@@ -4,7 +4,9 @@ local getArgs = require("Module:Arguments").getArgs
 local json = require("Module:Json")
 local Match = require("Module:Match")
 local processMatch = require("Module:Brkts/WikiSpecific").processMatch
-local utils = require("Module:LuaUtils")
+local Logic = require("Module:Logic")
+local Variables = require("Module:Variables")
+local utils = require("Module:LuaUtils")--only needed for "utils.string.split"
 local args
 local errorCat = ''
 
@@ -23,7 +25,7 @@ function p.luaMatchlist(frame, args, matchBuilder)
         error("argument 'id' is empty")
     end
 
-    require('Module:DevFlags').matchGroupDev = utils.misc.readBool(args.dev)
+    require('Module:DevFlags').matchGroupDev = Logic.readBool(args.dev)
 
     -- make sure bracket id is valid
     validateBracketID(bracketid)
@@ -83,7 +85,7 @@ function p.luaMatchlist(frame, args, matchBuilder)
             bd["header"] = header
         end
 
-        bd["bracketindex"] = utils.mw.varGet("match2bracketindex", 0)
+        bd["bracketindex"] = Variables.varDefault("match2bracketindex", 0)
 
         match["bracketdata"] = json.stringify(bd)
 
@@ -99,8 +101,8 @@ function p.luaMatchlist(frame, args, matchBuilder)
     end
 
     -- store match data as variable to bypass LPDB on the same page
-    utils.mw.varDefine("match2bracket_" .. bracketid, _convertDataForStorage(storedData))
-    utils.mw.varDefine("match2bracketindex", utils.mw.varGet("match2bracketindex", 0) + 1)
+    Variables.varDefine("match2bracket_" .. bracketid, _convertDataForStorage(storedData))
+    Variables.varDefine("match2bracketindex", Variables.varDefault("match2bracketindex", 0) + 1)
     
     if args.hide ~= "true" then
         return errorCat .. tostring(MatchGroupDisplay.luaMatchlist(frame, {
@@ -129,7 +131,7 @@ function p.luaBracket(frame, args, matchBuilder)
         error("argument 'id' is empty")
     end
 
-    require('Module:DevFlags').matchGroupDev = utils.misc.readBool(args.dev)
+    require('Module:DevFlags').matchGroupDev = Logic.readBool(args.dev)
 
     -- make sure bracket id is valid
     validateBracketID(bracketid)
@@ -187,10 +189,10 @@ function p.luaBracket(frame, args, matchBuilder)
             -- apply bracket data
             bd["type"] = "bracket"
             local header = args[matchid .. "header"]
-            if not utils.misc.isEmpty(header) then
+            if not Logic.isEmpty(header) then
                 bd["header"] = header
             end
-            bd["bracketindex"] = utils.mw.varGet("match2bracketindex", 0)
+            bd["bracketindex"] = Variables.varDefault("match2bracketindex", 0)
             local winnerTo = match["winnerto"]
             if winnerTo ~= nil then
                 local winnerToMatch = ""
@@ -235,8 +237,8 @@ function p.luaBracket(frame, args, matchBuilder)
     end
 
     -- store match data as variable to bypass LPDB on the same page
-    utils.mw.varDefine("match2bracket_" .. bracketid, _convertDataForStorage(storedData))
-    utils.mw.varDefine("match2bracketindex", utils.mw.varGet("match2bracketindex", 0) + 1)
+    Variables.varDefine("match2bracket_" .. bracketid, _convertDataForStorage(storedData))
+    Variables.varDefine("match2bracketindex", Variables.varDefault("match2bracketindex", 0) + 1)
 
     if args.hide ~= "true" then
         return errorCat .. tostring(MatchGroupDisplay.luaBracket(frame, {

--- a/match2/commons/match_group_display_bracket.lua
+++ b/match2/commons/match_group_display_bracket.lua
@@ -4,7 +4,10 @@ local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
-local LuaUtils = require('Module:LuaUtils')
+local LuaUtils = require('Module:LuaUtils')--only needed for "LuaUtils.string.endsWith"
+local Lua = require('Module:Lua')
+local Math = require('Module:Math')
+local Logic = require('Module:Logic')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local String = require('Module:String')
 local Table = require('Module:Table')
@@ -26,7 +29,7 @@ function BracketDisplay.configFromArgs(args)
     return {
         headerHeight = tonumber(args.headerHeight),
         headerMargin = tonumber(args.headerMargin),
-        hideRoundTitles = LuaUtils.misc.readBool(args.hideRoundTitles),
+        hideRoundTitles = Logic.readBool(args.hideRoundTitles),
         lineWidth = tonumber(args.lineWidth),
         matchMargin = tonumber(args.matchMargin),
         matchWidth = tonumber(args.matchWidth),
@@ -171,7 +174,7 @@ function BracketDisplay.computeBracketLayout(matchesById, config)
         )
 
         -- Compute partial sums of heights of lower round matches
-        local heightSums = LuaUtils.math.partialSums(
+        local heightSums = Math.partialSums(
             Array.map(lowerLayouts, function(layout) return layout.height end)
         )
 
@@ -599,7 +602,7 @@ function BracketDisplay.NodeLowerConnectors(props)
     )
 
     -- Compute partial sums of heights of lower round matches
-    local heightSums = LuaUtils.math.partialSums(
+    local heightSums = Math.partialSums(
         Array.map(lowerLayouts, function(layout) return layout.height end)
     )
 
@@ -741,8 +744,8 @@ by passing in a different props.OpponentEntry in the Bracket component.
 function BracketDisplay.DefaultOpponentEntry(props)
     local opponent = props.opponent
 
-    local OpponentDisplay = require('Module:DevFlags').matchGroupDev and LuaUtils.lua.requireIfExists('Module:OpponentDisplay/dev')
-        or LuaUtils.lua.requireIfExists('Module:OpponentDisplay')
+    local OpponentDisplay = require('Module:DevFlags').matchGroupDev and Lua.requireIfExists('Module:OpponentDisplay/dev')
+        or Lua.requireIfExists('Module:OpponentDisplay')
         or {}
     
     if OpponentDisplay.BracketOpponentEntry then

--- a/match2/commons/match_group_display_helper.lua
+++ b/match2/commons/match_group_display_helper.lua
@@ -1,9 +1,10 @@
 local Array = require('Module:Array')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
-local LuaUtils = require('Module:LuaUtils')
+local Lua = require('Module:Lua')
+local Variables = require('Module:Variables')
 local Table = require('Module:Table')
-local utils = require('Module:LuaUtils')
+local utils = require('Module:LuaUtils')--only needed for "utils.string.endsWith"
 
 local DisplayHelper = {}
 
@@ -38,7 +39,7 @@ end
 -- tries to get from var first, otherwise uses LPDB
 -- Deprecated
 function DisplayHelper.getMatches(bracketid)
-    local varData = utils.mw.varGet('match2bracket_' .. bracketid)
+    local varData = Variables.varDefault('match2bracket_' .. bracketid)
     if varData ~= nil then
         return Json.parse(varData)
     else
@@ -68,7 +69,7 @@ end
 -- @returns the type of a MatchGroup
 -- Deprecated
 function DisplayHelper.getMatchGroupType(bracketid)
-    local varData = utils.mw.varGet('match2bracket_' .. bracketid)
+    local varData = Variables.varDefault('match2bracket_' .. bracketid)
     if varData ~= nil then
         return Json.parse(Json.parse(varData)[1].match2bracketdata)['type']
     else
@@ -159,7 +160,7 @@ components.
 ]]
 DisplayHelper.DefaultMatchSummaryContainer = function(props)
     local DevFlags = require('Module:DevFlags')
-    local MatchSummaryModule = DevFlags.matchGroupDev and LuaUtils.lua.requireIfExists('Module:MatchSummary/dev')
+    local MatchSummaryModule = DevFlags.matchGroupDev and Lua.requireIfExists('Module:MatchSummary/dev')
         or require('Module:MatchSummary')
 
     if MatchSummaryModule.MatchSummaryContainer then

--- a/match2/commons/match_group_display_matchlist.lua
+++ b/match2/commons/match_group_display_matchlist.lua
@@ -2,7 +2,8 @@ local Class = require('Module:Class')
 local DisplayHelper = require('Module:MatchGroup/Display/Helper')
 local DisplayUtil = require('Module:DisplayUtil')
 local Json = require('Module:Json')
-local LuaUtils = require('Module:LuaUtils')
+local Logic = require('Module:Logic')
+local Lua = require('Module:Lua')
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
@@ -21,9 +22,9 @@ end
 
 MatchlistDisplay.configFromArgs = function(args)
     return {
-        attached = LuaUtils.misc.readBool(args.attached),
-        collapsed = LuaUtils.misc.readBool(args.collapsed),
-        collapsible = not LuaUtils.misc.readBool(args.nocollapse),
+        attached = Logic.readBool(args.attached),
+        collapsed = Logic.readBool(args.collapsed),
+        collapsible = not Logic.readBool(args.nocollapse),
         width = tonumber(string.gsub(args.width or '', 'px', ''), nil),
     }
 end
@@ -78,7 +79,7 @@ function MatchlistDisplay.Matchlist(props)
         Score = propsConfig.Score or MatchlistDisplay.DefaultScore,
         attached = propsConfig.attached or false,
         collapsed = propsConfig.collapsed or false,
-        collapsible = LuaUtils.misc.emptyOr(propsConfig.collapsible, true),
+        collapsible = Logic.emptyOr(propsConfig.collapsible, true),
         matchHasDetails = propsConfig.matchHasDetails or DisplayHelper.defaultMatchHasDetails,
         width = propsConfig.width or 300,
     }
@@ -260,8 +261,8 @@ function MatchlistDisplay.DefaultOpponent(props)
         playerRecord.extradata = Json.parseIfString(playerRecord.extradata) or {}
     end
     
-    local OpponentDisplay = require('Module:DevFlags').matchGroupDev and LuaUtils.lua.requireIfExists('Module:OpponentDisplay/dev')
-        or LuaUtils.lua.requireIfExists('Module:OpponentDisplay')
+    local OpponentDisplay = require('Module:DevFlags').matchGroupDev and Lua.requireIfExists('Module:OpponentDisplay/dev')
+        or Lua.requireIfExists('Module:OpponentDisplay')
         or {}
     return OpponentDisplay.luaGet(
         mw.getCurrentFrame(),
@@ -287,8 +288,8 @@ function MatchlistDisplay.DefaultScore(props)
         playerRecord.extradata = Json.parseIfString(playerRecord.extradata) or {}
     end
     
-    local OpponentDisplay = require('Module:DevFlags').matchGroupDev and LuaUtils.lua.requireIfExists('Module:OpponentDisplay/dev')
-        or LuaUtils.lua.requireIfExists('Module:OpponentDisplay')
+    local OpponentDisplay = require('Module:DevFlags').matchGroupDev and Lua.requireIfExists('Module:OpponentDisplay/dev')
+        or Lua.requireIfExists('Module:OpponentDisplay')
         or {}
     return OpponentDisplay.luaGet(
         mw.getCurrentFrame(),

--- a/match2/commons/match_group_util.lua
+++ b/match2/commons/match_group_util.lua
@@ -1,7 +1,8 @@
 local Array = require('Module:Array')
 local FnUtil = require('Module:FnUtil')
 local Json = require('Module:Json')
-local LuaUtils = require('Module:LuaUtils')
+local Logic = require('Module:Logic')
+local Variables = require('Module:Variables')
 local String = require('Module:String')
 local Table = require('Module:Table')
 local TypeUtil = require('Module:TypeUtil')
@@ -106,7 +107,7 @@ variables before fetching from LPDB. Returns a list of records
 ordered lexicographically by matchId.
 ]]
 function MatchGroupUtil.fetchMatchRecords(bracketId)
-    local varData = LuaUtils.mw.varGet("match2bracket_" .. bracketId)
+    local varData = Variables.varDefault("match2bracket_" .. bracketId)
     if varData then
         return Json.parse(varData)
     else
@@ -163,8 +164,8 @@ function MatchGroupUtil.matchFromRecord(record)
         comment = nilIfEmpty(extradata.comment),
         extradata = extradata,
         date = record.date,
-        dateIsExact = LuaUtils.misc.readBool(record.dateexact),
-        finished = LuaUtils.misc.readBool(record.finished),
+        dateIsExact = Logic.readBool(record.dateexact),
+        finished = Logic.readBool(record.finished),
         games = Array.map(record.match2games, MatchGroupUtil.gameFromRecord),
         links = Json.parseIfString(record.links) or {},
         matchId = record.match2id,
@@ -201,10 +202,10 @@ function MatchGroupUtil.bracketDataFromRecord(data, opponentCount)
             bracketSection = data.bracketsection,
             header = nilIfEmpty(data.header),
             lowerMatches = lowerMatches,
-            qualLose = LuaUtils.misc.readBool(data.quallose),
+            qualLose = Logic.readBool(data.quallose),
             qualLoseLiteral = nilIfEmpty(data.qualLoseLiteral),
             qualSkip = tonumber(data.qualskip) or data.qualskip == 'true' and 1 or 0,
-            qualWin = LuaUtils.misc.readBool(data.qualwin),
+            qualWin = Logic.readBool(data.qualwin),
             qualWinLiteral = nilIfEmpty(data.qualWinLiteral),
             skipRound = tonumber(data.skipround) or data.skipround == 'true' and 1 or 0,
             thirdPlaceMatchId = nilIfEmpty(data.thirdplace),

--- a/match2/commons/match_subobjects.lua
+++ b/match2/commons/match_subobjects.lua
@@ -1,18 +1,21 @@
 local p = {}
 
 local json = require("Module:Json")
-local utils = require("Module:LuaUtils")
+local Table = require("Module:Table")
+local Logic = require("Module:Logic")
+local utils = require("Module:LuaUtils")--only needed for "utils.string.startsWith"
+local getArgs = require("Module:Arguments").getArgs
 local wikiSpec = require("Module:Brkts/WikiSpecific")
 
 local ALLOWED_OPPONENT_TYPES = { "literal", "team", "solo", "duo", "trio", "quad" }
 
 function p.getOpponent(frame)
-  	local args = utils.frame.getArgs(frame)
+  	local args = getArgs(frame)
   	return p.luaGetOpponent(frame, args)
 end
 
 function p.luaGetOpponent(frame, args)
-	if not utils.table.includes(ALLOWED_OPPONENT_TYPES, args.type) then
+	if not Table.includes(ALLOWED_OPPONENT_TYPES, args.type) then
 		error("Unknown opponent type " .. args.type)
 	end
 	args = wikiSpec.processOpponent(frame, args)  
@@ -29,13 +32,13 @@ function p.luaGetOpponent(frame, args)
 end
 
 function p.getMap(frame)
-  	local args = utils.frame.getArgs(frame)
+  	local args = getArgs(frame)
   	return p.luaGetMap(frame, args)
 end
 
 function p.luaGetMap(frame, args)
   	-- dont save map if 'map' is not filled in
-  	if utils.misc.isEmpty(args.map) then
+  	if Logic.isEmpty(args.map) then
 		return nil
 	else
 		args = wikiSpec.processMap(frame, args)
@@ -76,7 +79,7 @@ function p.luaGetMap(frame, args)
 end
 
 function p.getRound(frame)
-    local args = utils.frame.getArgs(frame)
+    local args = getArgs(frame)
     return p.luaGetRound(frame, args)
 end
 
@@ -85,7 +88,7 @@ function p.luaGetRound(frame, args)
 end
 
 function p.getPlayer(frame)
-  	local args = utils.frame.getArgs(frame)
+  	local args = getArgs(frame)
   	return p.luaGetPlayer(frame, args)
 end
 

--- a/match2/wikis/rocketleague/brkts_wiki_specific.lua
+++ b/match2/wikis/rocketleague/brkts_wiki_specific.lua
@@ -3,6 +3,9 @@ local p = require("Module:Brkts/WikiSpecific/Base")
 local json = require("Module:Json")
 local Match = require("Module:Match")
 local utils = require("Module:LuaUtils")
+local Table = require("Module:Table")
+local Variables = require("Module:Variables")
+local Logic = require("Module:Logic")
 local getIconName = require("Module:IconName").luaGet
 local _frame
 
@@ -57,7 +60,7 @@ function p.processOpponent(frame, opponent)
 	end
   
   	-- process opponent
-  	if not utils.misc.isEmpty(opponent.template) then
+  	if not Logic.isEmpty(opponent.template) then
 		opponent.name = opponent.name or opponentFunctions.getTeamName(opponent.template)
 	end
   	
@@ -101,7 +104,7 @@ end
 function matchFunctions.getDateStuff(match)
   	local lang = mw.getContentLanguage()
   	-- parse date string with abbr
-  	if not utils.misc.isEmpty(match.date) then
+  	if not Logic.isEmpty(match.date) then
 		local matchString = match.date or ""
 		local timezone = utils.string.split(
 			utils.string.split(matchString, "data%-tz%=\"")[2] or "",
@@ -110,45 +113,45 @@ function matchFunctions.getDateStuff(match)
 		match.date = matchDate .. timezone
 		match.dateexact = utils.string.contains(match.date, "%+") or utils.string.contains(match.date, "%-")
 	else
-		match.date = lang:formatDate('c', (utils.mw.varGet("tournament_date", "") or "") .. " + " .. utils.mw.varGet("num_missing_dates", "0") .. " second")
+		match.date = lang:formatDate('c', (Variables.varDefault("tournament_date", "") or "") .. " + " .. Variables.varDefault("num_missing_dates", "0") .. " second")
 		match.dateexact = false
-		utils.mw.varDefine("num_missing_dates", utils.mw.varGet("num_missing_dates", 0) + 1)
+		Variables.varDefine("num_missing_dates", Variables.varDefault("num_missing_dates", 0) + 1)
 	end
   	return match
 end
 
 function matchFunctions.getTournamentVars(match)
-	match.mode = utils.misc.emptyOr(match.mode, utils.mw.varGet("tournament_mode", "3v3"))
-  	match.type = utils.misc.emptyOr(match.type, utils.mw.varGet("tournament_type"))
-	match.tournament = utils.misc.emptyOr(match.tournament, utils.mw.varGet("tournament_name"))
-  	match.tickername = utils.misc.emptyOr(match.tickername, utils.mw.varGet("tournament_ticker_name"))
-  	match.shortname = utils.misc.emptyOr(match.shortname, utils.mw.varGet("tournament_shortname"))
-  	match.series = utils.misc.emptyOr(match.series, utils.mw.varGet("tournament_series"))
-  	match.icon = utils.misc.emptyOr(match.icon, utils.mw.varGet("tournament_icon"))
-  	match.liquipediatier = utils.misc.emptyOr(match.liquipediatier, utils.mw.varGet("tournament_tier"))
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault("tournament_mode", "3v3"))
+  	match.type = Logic.emptyOr(match.type, Variables.varDefault("tournament_type"))
+	match.tournament = Logic.emptyOr(match.tournament, Variables.varDefault("tournament_name"))
+  	match.tickername = Logic.emptyOr(match.tickername, Variables.varDefault("tournament_ticker_name"))
+  	match.shortname = Logic.emptyOr(match.shortname, Variables.varDefault("tournament_shortname"))
+  	match.series = Logic.emptyOr(match.series, Variables.varDefault("tournament_series"))
+  	match.icon = Logic.emptyOr(match.icon, Variables.varDefault("tournament_icon"))
+  	match.liquipediatier = Logic.emptyOr(match.liquipediatier, Variables.varDefault("tournament_tier"))
   	return match
 end
 
 function matchFunctions.getVodStuff(match)
   	match.stream = match.stream or {}
   	match.stream = json.stringify({
-		stream = utils.misc.emptyOr(match.stream.stream, utils.mw.varGet("stream")),
-	  	twitch = utils.misc.emptyOr(match.stream.twitch or match.twitch, utils.mw.varGet("twitch")),
-	  	twitch2 = utils.misc.emptyOr(match.stream.twitch2 or match.twitch2, utils.mw.varGet("twitch2")),
-	  	afreeca = utils.misc.emptyOr(match.stream.afreeca or match.afreeca, utils.mw.varGet("afreeca")),
-	  	afreecatv = utils.misc.emptyOr(match.stream.afreecatv or match.afreecatv, utils.mw.varGet("afreecatv")),
-	  	dailymotion = utils.misc.emptyOr(match.stream.dailymotion or match.dailymotion, utils.mw.varGet("dailymotion")),
-	  	douyu = utils.misc.emptyOr(match.stream.douyu or match.douyu, utils.mw.varGet("douyu")),
-	  	smashcast = utils.misc.emptyOr(match.stream.smashcast or match.smashcast, utils.mw.varGet("smashcast")),
-	  	youtube = utils.misc.emptyOr(match.stream.youtube or match.youtube, utils.mw.varGet("youtube"))
+		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault("stream")),
+	  	twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault("twitch")),
+	  	twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault("twitch2")),
+	  	afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault("afreeca")),
+	  	afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault("afreecatv")),
+	  	dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault("dailymotion")),
+	  	douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault("douyu")),
+	  	smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault("smashcast")),
+	  	youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault("youtube"))
   	})
-  	match.vod = utils.misc.emptyOr(match.vod, utils.mw.varGet("vod"))
+  	match.vod = Logic.emptyOr(match.vod, Variables.varDefault("vod"))
   	
   	-- apply vodgames
   	for index = 1, MAX_NUM_VODGAMES do
 		local vodgame = match["vodgame" .. index]
-		if not utils.misc.isEmpty(vodgame) then
-	  		local map = utils.misc.emptyOr(match["map" .. index], nil, {})
+		if not Logic.isEmpty(vodgame) then
+	  		local map = Logic.emptyOr(match["map" .. index], nil, {})
 	  		if type(map) == "string" then
 				map = json.parse(map)
 			end
@@ -163,13 +166,13 @@ function matchFunctions.getExtraData(match)
   	local opponent1 = match.opponent1 or {}
   	local opponent2 = match.opponent2 or {}
   	match.extradata = json.stringify({
-	  matchsection = utils.mw.varGet("matchsection"),
+	  matchsection = Variables.varDefault("matchsection"),
 	  team1icon = getIconName(opponent1.template or ""),
 	  team2icon = getIconName(opponent2.template or ""),
-	  lastgame = utils.mw.varGet("last_game"),
+	  lastgame = Variables.varDefault("last_game"),
 	  comment = match.comment,
 	  octane = match.octane,
-	  liquipediatier2 = utils.mw.varGet("tournament_tier2"),
+	  liquipediatier2 = Variables.varDefault("tournament_tier2"),
 	  isconverted = 0
 	})
   	return match
@@ -182,7 +185,7 @@ function matchFunctions.getOpponents(args)
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		-- read opponent
 		opponent = args["opponent" .. opponentIndex]
-		if not utils.misc.isEmpty(opponent) then
+		if not Logic.isEmpty(opponent) then
 			if type(opponent) == "string" then
 				opponent = json.parse(opponent)
 			end
@@ -190,21 +193,21 @@ function matchFunctions.getOpponents(args)
 			if utils.misc.isNumeric(opponent.score) then
 				opponent.status = "S"
 				isScoreSet = true
-			elseif utils.table.includes(ALLOWED_STATUSES, opponent.score) then
+			elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
 				opponent.status = opponent.score
 				opponent.score = -1
 			end
 			opponents[opponentIndex] = opponent
 	  
 	  		-- get players from vars for teams
-	  		if opponent.type == "team" and not utils.misc.isEmpty(opponent.name) then
+	  		if opponent.type == "team" and not Logic.isEmpty(opponent.name) then
 	  			args = matchFunctions.getPlayers(args, opponentIndex, opponent.name)
 			end
 	  	end
 	end
 	
 	-- see if match should actually be finished if score is set
-  	if isScoreSet and not utils.misc.readBool(args.finished) then
+  	if isScoreSet and not Logic.readBool(args.finished) then
 		local currentUnixTime = os.time(os.date("!*t"))
 		local lang = mw.getContentLanguage()
 		local matchUnixTime = tonumber(lang:formatDate('U', args.date))
@@ -215,7 +218,7 @@ function matchFunctions.getOpponents(args)
 	end
 	
 	-- apply placements and winner if finshed
-  	if utils.misc.readBool(args.finished) then
+  	if Logic.readBool(args.finished) then
 		local placement = 1
 		for opponentIndex, opponent in utils.iter.spairs(opponents, placementSortFunction) do
 	  		if placement == 1 then
@@ -241,9 +244,9 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 		if type(player) == "string" then
 			player = json.parse(player)
 		end
-		player.name = player.name or utils.mw.varGet(teamName .. "_p" .. playerIndex)
-		player.flag = player.flag or utils.mw.varGet(teamName .. "_p" .. playerIndex .. "flag")
-		if not utils.table.isEmpty(player) then
+		player.name = player.name or Variables.varDefault(teamName .. "_p" .. playerIndex)
+		player.flag = player.flag or Variables.varDefault(teamName .. "_p" .. playerIndex .. "flag")
+		if not Table.isEmpty(player) then
 			match["opponent" .. opponentIndex .. "_p" .. playerIndex] = player
 		end
 	end
@@ -269,7 +272,7 @@ function mapFunctions.getScoresAndWinner(map)
 		-- read scores
 		local score = map["score" .. scoreIndex]
 		local obj = {}
-		if not utils.misc.isEmpty(score) then
+		if not Logic.isEmpty(score) then
 	  		if utils.misc.isNumeric(score) then
 				obj.status = "S"
 				obj.score = score
@@ -291,14 +294,14 @@ function mapFunctions.getScoresAndWinner(map)
 end
 
 function mapFunctions.getTournamentVars(map)
-	map.mode = utils.misc.emptyOr(map.mode, utils.mw.varGet("tournament_mode", "3v3"))
-  	map.type = utils.misc.emptyOr(map.type, utils.mw.varGet("tournament_type"))
-	map.tournament = utils.misc.emptyOr(map.tournament, utils.mw.varGet("tournament_name"))
-  	map.tickername = utils.misc.emptyOr(map.tickername, utils.mw.varGet("tournament_ticker_name"))
-  	map.shortname = utils.misc.emptyOr(map.shortname, utils.mw.varGet("tournament_shortname"))
-  	map.series = utils.misc.emptyOr(map.series, utils.mw.varGet("tournament_series"))
-  	map.icon = utils.misc.emptyOr(map.icon, utils.mw.varGet("tournament_icon"))
-  	map.liquipediatier = utils.misc.emptyOr(map.liquipediatier, utils.mw.varGet("tournament_tier"))
+	map.mode = Logic.emptyOr(map.mode, Variables.varDefault("tournament_mode", "3v3"))
+  	map.type = Logic.emptyOr(map.type, Variables.varDefault("tournament_type"))
+	map.tournament = Logic.emptyOr(map.tournament, Variables.varDefault("tournament_name"))
+  	map.tickername = Logic.emptyOr(map.tickername, Variables.varDefault("tournament_ticker_name"))
+  	map.shortname = Logic.emptyOr(map.shortname, Variables.varDefault("tournament_shortname"))
+  	map.series = Logic.emptyOr(map.series, Variables.varDefault("tournament_series"))
+  	map.icon = Logic.emptyOr(map.icon, Variables.varDefault("tournament_icon"))
+  	map.liquipediatier = Logic.emptyOr(map.liquipediatier, Variables.varDefault("tournament_tier"))
   	return map
 end
 
@@ -312,7 +315,7 @@ function mapFunctions.getParticipantsData(map)
   	scorers = {}
   	for g = 1, 1000 do
 		local scorer = map["goal" .. g .. "player"]
-		if utils.misc.isEmpty(scorer) then
+		if Logic.isEmpty(scorer) then
 	  		break
 	  	elseif scorer:match("op%d_p%d") then
 	  		scorer = scorer:gsub("op", ""):gsub("p", "")
@@ -333,9 +336,9 @@ function mapFunctions.getParticipantsData(map)
 	  		local opstring = "opponent" .. o .. "_p" .. p
 	  		local goals = map[opstring .. "goals"]
 	  		local car = map[opstring .. "car"]
-	  		participant.goals = utils.misc.isEmpty(goals) and participant.goals or goals
-	  		participant.car = utils.misc.isEmpty(car) and participant.car or car
-	  		if not utils.table.isEmpty(participant) then
+	  		participant.goals = Logic.isEmpty(goals) and participant.goals or goals
+	  		participant.car = Logic.isEmpty(car) and participant.car or car
+	  		if not Table.isEmpty(participant) then
 				participants[o .. "_" .. p] = participant
 			end
 	  	end

--- a/match2/wikis/rocketleague/opponent_display.lua
+++ b/match2/wikis/rocketleague/opponent_display.lua
@@ -2,7 +2,8 @@ local p = {}
 
 local getArgs = require("Module:Arguments").getArgs
 local json = require("Module:Json")
-local utils = require("Module:LuaUtils")
+local utils = require("Module:LuaUtils")--only needed for "utils.string.startsWith"
+local Template = require("Module:Template")
 local htmlCreate = mw.html.create
 
 function p.get(frame)
@@ -30,7 +31,7 @@ function p.luaGet(frame, args)
 		elseif opponentType == "solo" then
 	  		local container = htmlCreate("div")
 	  			:addClass("brkts-opponent-template-container brkts-player-container")
-	  			:wikitext(utils.frame.protectedExpansion(frame, "Player", { args.match2player1_name , flag = args.match2player1_flag }))
+	  			:wikitext(Template.safeExpand(frame, "Player", { args.match2player1_name , flag = args.match2player1_flag }))
 	  		wrapper:node(container)
 	  	elseif opponentType == "literal" then
 	  		local container = htmlCreate("div")
@@ -101,8 +102,8 @@ end
 function getTeam(frame, template)
   	local teamExists = mw.ext.TeamTemplate.teamexists(template)
 	local team = {
-		bracket = teamExists and mw.ext.TeamTemplate.teambracket(template) or utils.frame.protectedExpansion(frame, "TeamBracket", { template }),
-	  	short = teamExists and mw.ext.TeamTemplate.teamshort(template) or utils.frame.protectedExpansion(frame, "TeamShort", { template })
+		bracket = teamExists and mw.ext.TeamTemplate.teambracket(template) or Template.safeExpand(frame, "TeamBracket", { template }),
+	  	short = teamExists and mw.ext.TeamTemplate.teamshort(template) or Template.safeExpand(frame, "TeamShort", { template })
 	}
 	return team
 end
@@ -110,9 +111,9 @@ end
 function getTeamMatchList(frame, template, side)
   	local teamExists = mw.ext.TeamTemplate.teamexists(template)
   	if side == "left" then
-		return teamExists and mw.ext.TeamTemplate.team2short(template) or utils.frame.protectedExpansion(frame, "Team2Short", { template })
+		return teamExists and mw.ext.TeamTemplate.team2short(template) or Template.safeExpand(frame, "Team2Short", { template })
 	elseif side == "right" then
-		return teamExists and mw.ext.TeamTemplate.teamshort(template) or utils.frame.protectedExpansion(frame, "TeamShort", { template })
+		return teamExists and mw.ext.TeamTemplate.teamshort(template) or Template.safeExpand(frame, "TeamShort", { template })
 	end
 end
 

--- a/match2/wikis/valorant/big_match.lua
+++ b/match2/wikis/valorant/big_match.lua
@@ -8,7 +8,7 @@ local Match = require("Module:Match")
 local LocalMatch = require("Module:Brkts/WikiSpecific")
 local Class = require('Module:Class')
 local Template = require('Module:Template')
-local LuaUtils = require('Module:LuaUtils')
+local Logic = require('Module:Logic')
 local DivTable = require('Module:DivTable')
 local Links = require('Module:Links')
 local Countdown = require('Module:Countdown')
@@ -55,7 +55,7 @@ function BigMatch:header(match, opponent1, opponent2, tournament)
 
     local stream = Json.parse(match.stream or '{}')
     stream.date = mw.getContentLanguage():formatDate('r', match.date)
-    stream.finished = LuaUtils.misc.readBool(match.finished) and 'true' or ''
+    stream.finished = Logic.readBool(match.finished) and 'true' or ''
     local divider = self:_createTeamSeparator(match.format, stream)
 
     local teamsRow =  mw.html.create('div'):addClass('fb-match-page-header-teams row')

--- a/match2/wikis/valorant/brkts_wiki_specific.lua
+++ b/match2/wikis/valorant/brkts_wiki_specific.lua
@@ -3,6 +3,8 @@ local Table = require("Module:Table")
 local WikiSpecificBase = require('Module:Brkts/WikiSpecific/Base')
 local getIconName = require("Module:IconName").luaGet
 local json = require("Module:Json")
+local Logic = require("Module:Logic")
+local Variables = require("Module:Variables")
 local utils = require("Module:LuaUtils")
 
 local _frame
@@ -62,7 +64,7 @@ function p.processOpponent(frame, opponent)
 	end
   
   	-- process opponent
-  	if not utils.misc.isEmpty(opponent.template) then
+  	if not Logic.isEmpty(opponent.template) then
 		opponent.name = opponent.name or opponentFunctions.getTeamName(opponent.template)
 	end
   	
@@ -106,7 +108,7 @@ end
 function matchFunctions.getDateStuff(match)
   	local lang = mw.getContentLanguage()
   	-- parse date string with abbr
-  	if not utils.misc.isEmpty(match.date) then
+  	if not Logic.isEmpty(match.date) then
 		local matchString = match.date or ""
 		local timezone = utils.string.split(
 			utils.string.split(matchString, "data%-tz%=\"")[2] or "",
@@ -115,45 +117,45 @@ function matchFunctions.getDateStuff(match)
 		match.date = matchDate .. timezone
 		match.dateexact = utils.string.contains(match.date, "%+") or utils.string.contains(match.date, "%-")
 	else
-		match.date = lang:formatDate('c', (utils.mw.varGet("tournament_date", "") or "") .. " + " .. utils.mw.varGet("num_missing_dates", "0") .. " second")
+		match.date = lang:formatDate('c', (Variables.varDefault("tournament_date", "") or "") .. " + " .. Variables.varDefault("num_missing_dates", "0") .. " second")
 		match.dateexact = false
-		utils.mw.varDefine("num_missing_dates", utils.mw.varGet("num_missing_dates", 0) + 1)
+		Variables.varDefine("num_missing_dates", Variables.varDefault("num_missing_dates", 0) + 1)
 	end
   	return match
 end
 
 function matchFunctions.getTournamentVars(match)
-	match.mode = utils.misc.emptyOr(match.mode, utils.mw.varGet("tournament_mode", "3v3"))
-  	match.type = utils.misc.emptyOr(match.type, utils.mw.varGet("tournament_type"))
-	match.tournament = utils.misc.emptyOr(match.tournament, utils.mw.varGet("tournament_name"))
-  	match.tickername = utils.misc.emptyOr(match.tickername, utils.mw.varGet("tournament_ticker_name"))
-  	match.shortname = utils.misc.emptyOr(match.shortname, utils.mw.varGet("tournament_shortname"))
-  	match.series = utils.misc.emptyOr(match.series, utils.mw.varGet("tournament_series"))
-  	match.icon = utils.misc.emptyOr(match.icon, utils.mw.varGet("tournament_icon"))
-  	match.liquipediatier = utils.misc.emptyOr(match.liquipediatier, utils.mw.varGet("tournament_tier"))
+	match.mode = Logic.emptyOr(match.mode, Variables.varDefault("tournament_mode", "3v3"))
+  	match.type = Logic.emptyOr(match.type, Variables.varDefault("tournament_type"))
+	match.tournament = Logic.emptyOr(match.tournament, Variables.varDefault("tournament_name"))
+  	match.tickername = Logic.emptyOr(match.tickername, Variables.varDefault("tournament_ticker_name"))
+  	match.shortname = Logic.emptyOr(match.shortname, Variables.varDefault("tournament_shortname"))
+  	match.series = Logic.emptyOr(match.series, Variables.varDefault("tournament_series"))
+  	match.icon = Logic.emptyOr(match.icon, Variables.varDefault("tournament_icon"))
+  	match.liquipediatier = Logic.emptyOr(match.liquipediatier, Variables.varDefault("tournament_tier"))
   	return match
 end
 
 function matchFunctions.getVodStuff(match)
   	match.stream = match.stream or {}
   	match.stream = json.stringify({
-		stream = utils.misc.emptyOr(match.stream.stream, utils.mw.varGet("stream")),
-	  	twitch = utils.misc.emptyOr(match.stream.twitch or match.twitch, utils.mw.varGet("twitch")),
-	  	twitch2 = utils.misc.emptyOr(match.stream.twitch2 or match.twitch2, utils.mw.varGet("twitch2")),
-	  	afreeca = utils.misc.emptyOr(match.stream.afreeca or match.afreeca, utils.mw.varGet("afreeca")),
-	  	afreecatv = utils.misc.emptyOr(match.stream.afreecatv or match.afreecatv, utils.mw.varGet("afreecatv")),
-	  	dailymotion = utils.misc.emptyOr(match.stream.dailymotion or match.dailymotion, utils.mw.varGet("dailymotion")),
-	  	douyu = utils.misc.emptyOr(match.stream.douyu or match.douyu, utils.mw.varGet("douyu")),
-	  	smashcast = utils.misc.emptyOr(match.stream.smashcast or match.smashcast, utils.mw.varGet("smashcast")),
-	  	youtube = utils.misc.emptyOr(match.stream.youtube or match.youtube, utils.mw.varGet("youtube"))
+		stream = Logic.emptyOr(match.stream.stream, Variables.varDefault("stream")),
+	  	twitch = Logic.emptyOr(match.stream.twitch or match.twitch, Variables.varDefault("twitch")),
+	  	twitch2 = Logic.emptyOr(match.stream.twitch2 or match.twitch2, Variables.varDefault("twitch2")),
+	  	afreeca = Logic.emptyOr(match.stream.afreeca or match.afreeca, Variables.varDefault("afreeca")),
+	  	afreecatv = Logic.emptyOr(match.stream.afreecatv or match.afreecatv, Variables.varDefault("afreecatv")),
+	  	dailymotion = Logic.emptyOr(match.stream.dailymotion or match.dailymotion, Variables.varDefault("dailymotion")),
+	  	douyu = Logic.emptyOr(match.stream.douyu or match.douyu, Variables.varDefault("douyu")),
+	  	smashcast = Logic.emptyOr(match.stream.smashcast or match.smashcast, Variables.varDefault("smashcast")),
+	  	youtube = Logic.emptyOr(match.stream.youtube or match.youtube, Variables.varDefault("youtube"))
   	})
-  	match.vod = utils.misc.emptyOr(match.vod, utils.mw.varGet("vod"))
+  	match.vod = Logic.emptyOr(match.vod, Variables.varDefault("vod"))
   	
   	-- apply vodgames
   	for index = 1, MAX_NUM_VODGAMES do
 		local vodgame = match["vodgame" .. index]
-		if not utils.misc.isEmpty(vodgame) then
-	  		local map = utils.misc.emptyOr(match["map" .. index], nil, {})
+		if not Logic.isEmpty(vodgame) then
+	  		local map = Logic.emptyOr(match["map" .. index], nil, {})
 	  		if type(map) == "string" then
 				map = json.parse(map)
 			end
@@ -168,13 +170,13 @@ function matchFunctions.getExtraData(match)
   	local opponent1 = match.opponent1 or {}
   	local opponent2 = match.opponent2 or {}
   	match.extradata = json.stringify({
-	  matchsection = utils.mw.varGet("matchsection"),
+	  matchsection = Variables.varDefault("matchsection"),
 	  team1icon = getIconName(opponent1.template or ""),
 	  team2icon = getIconName(opponent2.template or ""),
-	  lastgame = utils.mw.varGet("last_game"),
+	  lastgame = Variables.varDefault("last_game"),
 	  comment = match.comment,
 	  octane = match.octane,
-	  liquipediatier2 = utils.mw.varGet("tournament_tier2"),
+	  liquipediatier2 = Variables.varDefault("tournament_tier2"),
 	  isconverted = 0
 	})
   	return match
@@ -187,7 +189,7 @@ function matchFunctions.getOpponents(args)
 	for opponentIndex = 1, MAX_NUM_OPPONENTS do
 		-- read opponent
 		opponent = args["opponent" .. opponentIndex]
-		if not utils.misc.isEmpty(opponent) then
+		if not Logic.isEmpty(opponent) then
 			if type(opponent) == "string" then
 				opponent = json.parse(opponent)
 			end
@@ -195,21 +197,21 @@ function matchFunctions.getOpponents(args)
 			if utils.misc.isNumeric(opponent.score) then
 				opponent.status = "S"
 				isScoreSet = true
-			elseif utils.table.includes(ALLOWED_STATUSES, opponent.score) then
+			elseif Table.includes(ALLOWED_STATUSES, opponent.score) then
 				opponent.status = opponent.score
 				opponent.score = -1
 			end
 			opponents[opponentIndex] = opponent
 	  
 	  		-- get players from vars for teams
-	  		if opponent.type == "team" and not utils.misc.isEmpty(opponent.name) then
+	  		if opponent.type == "team" and not Logic.isEmpty(opponent.name) then
 	  			args = matchFunctions.getPlayers(args, opponentIndex, opponent.name)
 			end
 	  	end
 	end
 	
 	-- see if match should actually be finished if score is set
-  	if isScoreSet and not utils.misc.readBool(args.finished) then
+  	if isScoreSet and not Logic.readBool(args.finished) then
 		local currentUnixTime = os.time(os.date("!*t"))
 		local lang = mw.getContentLanguage()
 		local matchUnixTime = tonumber(lang:formatDate('U', args.date))
@@ -220,7 +222,7 @@ function matchFunctions.getOpponents(args)
 	end
 	
 	-- apply placements and winner if finshed
-  	if utils.misc.readBool(args.finished) then
+  	if Logic.readBool(args.finished) then
 		local placement = 1
 		for opponentIndex, opponent in utils.iter.spairs(opponents, placementSortFunction) do
 	  		if placement == 1 then
@@ -246,9 +248,9 @@ function matchFunctions.getPlayers(match, opponentIndex, teamName)
 		if type(player) == "string" then
 			player = json.parse(player)
 		end
-		player.name = player.name or utils.mw.varGet(teamName .. "_p" .. playerIndex)
-		player.flag = player.flag or utils.mw.varGet(teamName .. "_p" .. playerIndex .. "flag")
-		if not utils.table.isEmpty(player) then
+		player.name = player.name or Variables.varDefault(teamName .. "_p" .. playerIndex)
+		player.flag = player.flag or Variables.varDefault(teamName .. "_p" .. playerIndex .. "flag")
+		if not Table.isEmpty(player) then
 			match["opponent" .. opponentIndex .. "_p" .. playerIndex] = player
 		end
 	end
@@ -279,11 +281,11 @@ function mapFunctions.getScoresAndWinner(map)
 		-- read scores
 		local score = map["score" .. scoreIndex]
 		local obj = {}
-		if not utils.misc.isEmpty(score) then
+		if not Logic.isEmpty(score) then
 	  		if utils.misc.isNumeric(score) then
 				obj.status = "S"
 				obj.score = score
-			elseif utils.table.includes(ALLOWED_STATUSES, score) then
+			elseif Table.includes(ALLOWED_STATUSES, score) then
 				obj.status = score
 				obj.score = -1
 			end
@@ -301,14 +303,14 @@ function mapFunctions.getScoresAndWinner(map)
 end
 
 function mapFunctions.getTournamentVars(map)
-	map.mode = utils.misc.emptyOr(map.mode, utils.mw.varGet("tournament_mode", "3v3"))
-  	map.type = utils.misc.emptyOr(map.type, utils.mw.varGet("tournament_type"))
-	map.tournament = utils.misc.emptyOr(map.tournament, utils.mw.varGet("tournament_name"))
-  	map.tickername = utils.misc.emptyOr(map.tickername, utils.mw.varGet("tournament_ticker_name"))
-  	map.shortname = utils.misc.emptyOr(map.shortname, utils.mw.varGet("tournament_shortname"))
-  	map.series = utils.misc.emptyOr(map.series, utils.mw.varGet("tournament_series"))
-  	map.icon = utils.misc.emptyOr(map.icon, utils.mw.varGet("tournament_icon"))
-  	map.liquipediatier = utils.misc.emptyOr(map.liquipediatier, utils.mw.varGet("tournament_tier"))
+	map.mode = Logic.emptyOr(map.mode, Variables.varDefault("tournament_mode", "3v3"))
+  	map.type = Logic.emptyOr(map.type, Variables.varDefault("tournament_type"))
+	map.tournament = Logic.emptyOr(map.tournament, Variables.varDefault("tournament_name"))
+  	map.tickername = Logic.emptyOr(map.tickername, Variables.varDefault("tournament_ticker_name"))
+  	map.shortname = Logic.emptyOr(map.shortname, Variables.varDefault("tournament_shortname"))
+  	map.series = Logic.emptyOr(map.series, Variables.varDefault("tournament_series"))
+  	map.icon = Logic.emptyOr(map.icon, Variables.varDefault("tournament_icon"))
+  	map.liquipediatier = Logic.emptyOr(map.liquipediatier, Variables.varDefault("tournament_tier"))
   	return map
 end
 
@@ -334,13 +336,13 @@ function mapFunctions.getParticipantsData(map)
                 local agent = stats["agent"]
                 local averageCombatScore = stats["acs"]
 
-                participant.kills = utils.misc.isEmpty(kills) and participant.kills or kills
-                participant.deaths = utils.misc.isEmpty(deaths) and participant.deaths or deaths
-                participant.assists = utils.misc.isEmpty(assists) and participant.assists or assists
-                participant.agent = utils.misc.isEmpty(agent) and participant.agent or agent
-                participant.acs = utils.misc.isEmpty(averageCombatScore) and participant.averagecombatscore or averageCombatScore
+                participant.kills = Logic.isEmpty(kills) and participant.kills or kills
+                participant.deaths = Logic.isEmpty(deaths) and participant.deaths or deaths
+                participant.assists = Logic.isEmpty(assists) and participant.assists or assists
+                participant.agent = Logic.isEmpty(agent) and participant.agent or agent
+                participant.acs = Logic.isEmpty(averageCombatScore) and participant.averagecombatscore or averageCombatScore
 
-                if not utils.table.isEmpty(participant) then
+                if not Table.isEmpty(participant) then
                     participants[o .. "_" .. p] = participant
                 end
             end
@@ -383,11 +385,11 @@ function roundFunctions.getRoundData(round)
 				local buy = stats["buy"]
 				local bank = stats["bank"]
 
-                participant.kills = utils.misc.isEmpty(kills) and participant.kills or kills
-                participant.score = utils.misc.isEmpty(score) and participant.score or score
-                participant.weapon = utils.misc.isEmpty(weapon) and participant.weapon or weapon
-                participant.buy = utils.misc.isEmpty(buy) and participant.buy or buy
-                participant.bank = utils.misc.isEmpty(bank) and participant.bank or bank
+                participant.kills = Logic.isEmpty(kills) and participant.kills or kills
+                participant.score = Logic.isEmpty(score) and participant.score or score
+                participant.weapon = Logic.isEmpty(weapon) and participant.weapon or weapon
+                participant.buy = Logic.isEmpty(buy) and participant.buy or buy
+                participant.bank = Logic.isEmpty(bank) and participant.bank or bank
 
                 if not utils.table.isEmpty(participant) then
                     participants[o .. "_" .. p] = participant

--- a/match2/wikis/valorant/match_summary.lua
+++ b/match2/wikis/valorant/match_summary.lua
@@ -1,7 +1,7 @@
 local Arguments = require('Module:Arguments')
 local Class = require('Module:Class')
 local Countdown = require('Module:Countdown')
-local LuaUtils = require("Module:LuaUtils")
+local Logic = require("Module:Logic")
 local MatchGroupUtil = require('Module:MatchGroup/Util')
 local MatchSummary = require('Module:MatchSummary/Base')
 local Table = require('Module:Table')
@@ -30,7 +30,7 @@ function Agents:setRight()
 end
 
 function Agents:add(frame, agent)
-    if LuaUtils.misc.isEmpty(agent) then
+    if Logic.isEmpty(agent) then
         return self
     end
 
@@ -247,7 +247,7 @@ function CustomMatchSummary._createMap(frame, game)
     end
     row:addElement(CustomMatchSummary._createCheckMark(game.winner == 2))
 
-    if not LuaUtils.misc.isEmpty(game.comment) then
+    if not Logic.isEmpty(game.comment) then
         row:addElement(MatchSummary.Break():create())
         local comment = mw.html.create('div')
         comment :wikitext(game.comment)


### PR DESCRIPTION
Kick lots of LuaUtils usage

Usage that still remains is mostly string stuff and iter stuff.

(For the iter stuff the question is if we move it into Module:Table or give it a Module itself.
For the string stuff question is how we proceed as the current string module is mostly for direct usage from wikicode and not from inside Modules. On top of that the "endsWith" function exists in that Module, but is quite different (returns strings instead of booleans and has pattern matching options.)